### PR TITLE
Specified port is ignored when building a server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 .idea_modules
+target
+

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,9 @@ resolvers += "Twitter Maven repo" at "http://maven.twttr.com/"
 
 libraryDependencies += "com.twitter" % "finagle-redis" % "4.0.5"
 
+libraryDependencies += "net.debasishg" %% "redisclient" % "2.5" % "test"
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "1.7.2" % "test"
 
 scalacOptions += "-unchecked"
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.0.0")
+
+

--- a/src/main/scala/com/github/cb372/fedis/Server.scala
+++ b/src/main/scala/com/github/cb372/fedis/Server.scala
@@ -21,7 +21,7 @@ object Server {
 
     ServerBuilder()
       .codec(RedisServerCodec())
-      .bindTo(new InetSocketAddress(6379))
+      .bindTo(new InetSocketAddress(port))
       .name("redisserver")
       .build(myService)
     }

--- a/src/test/scala/com/github/cb372/fedis/ServerSpec.scala
+++ b/src/test/scala/com/github/cb372/fedis/ServerSpec.scala
@@ -1,0 +1,20 @@
+package com.github.cb372.fedis
+
+import org.scalatest._
+import org.scalatest.matchers._
+
+class ServerSpec extends FlatSpec with ShouldMatchers {
+
+  behavior of "Server"
+
+  it should "listen a specified port" in {
+    Server.build(port = 6389)
+    import com.redis._
+    val r = new RedisClient("localhost", 6389)
+    r.set("key", "some value") should equal(true)
+    val v = r.get("key")
+    v.isDefined should equal(true)
+    v.get should equal("some value")
+  }
+
+}


### PR DESCRIPTION
I tried fedis and felt it's so useful!

I found that `ServerBuilder` ignores the specified port number.

Please check it out.
